### PR TITLE
composition.hpp full rewrite

### DIFF
--- a/src/composition.hpp
+++ b/src/composition.hpp
@@ -34,7 +34,7 @@ class fondue::composition<R(Arg_T)> {
 		inline std::shared_future<R> make_ready_at_thread_exit(Arg_T arg);
 		
 		// Returns the shared future of the composition
-		[[nodiscard]]
+		[[nodiscard, gnu::pure]]
 		inline std::shared_future<R> get_future() const noexcept;
 		
 		// Composes *this ∘ c

--- a/src/composition.hpp
+++ b/src/composition.hpp
@@ -151,7 +151,7 @@ template <class R, class Arg_T>
 constexpr fondue::composition<R(Arg_T)>::composition(std::function<R(Arg_T)> &&f) noexcept
 	: func(f), ptask(std::move(std::packaged_task<R(Arg_T)>(std::move(f)))) 
 {
-	sharedf = ptask.get_future().share();
+	sharedf = std::move(ptask.get_future().share());
 }
 
 template <class R, class Arg_T>
@@ -160,7 +160,7 @@ constexpr fondue::composition<R(Arg_T)>::composition(const fondue::composition<R
 {
 	std::function<R(Arg_T)> tempcopy = func;
 	ptask = std::move(std::packaged_task<R(Arg_T)>(std::move(tempcopy)));
-	sharedf = ptask.get_future().share();
+	sharedf = std::move(ptask.get_future().share());
 }
 
 #endif

--- a/tests/composition/Makefile
+++ b/tests/composition/Makefile
@@ -5,7 +5,7 @@ CXXWARNINGS = -Wall -Wextra -Wpedantic -Wfatal-errors -Wvla -Wlogical-op -pedant
 # The flags we should pass to our compiler.
 CXXFLAGS_NORMAL = -O2 -pthread $(CXXWARNINGS) $(CXXVERSION)
 # The flags we should pass to our compiler when debugging.
-CXXFLAGS_DEBUG = -g $(CXXFLAGS_NORMAL)
+CXXFLAGS_DEBUG = -g -O0 -pthread $(CXXWARNINGS) $(CXXVERSION)
 
 # Relative path to the source directory of fondue.
 src = ../../src

--- a/tests/composition/Makefile
+++ b/tests/composition/Makefile
@@ -3,9 +3,9 @@ CXXVERSION = -std=c++14
 # All of the things we should make our compiler scream in agony for.
 CXXWARNINGS = -Wall -Wextra -Wpedantic -Wfatal-errors -Wvla -Wlogical-op -pedantic-errors
 # The flags we should pass to our compiler.
-CXXFLAGS_NORMAL = -O2 -pthread $(CXXWARNINGS) $(CXXVERSION)
+CXXFLAGS_NORMAL = -O2 $(CXXWARNINGS) $(CXXVERSION)
 # The flags we should pass to our compiler when debugging.
-CXXFLAGS_DEBUG = -g -O0 -pthread $(CXXWARNINGS) $(CXXVERSION)
+CXXFLAGS_DEBUG = -g -O0 $(CXXWARNINGS) $(CXXVERSION)
 
 # Relative path to the source directory of fondue.
 src = ../../src

--- a/tests/composition/Makefile
+++ b/tests/composition/Makefile
@@ -13,7 +13,7 @@ src = ../../src
 build = build
 
 # Our source files we're compiling.
-CXX_COMPILATION_OBJECTS = single_type.cpp multi_type.cpp
+CXX_COMPILATION_OBJECTS = single_type.cpp multi_type.cpp static_comp.cpp 
 # A variable which will store the name of the associated executable given a compilation object.
 CXX_EXECUTABLE = $(build)/$(basename $(notdir $@))
 # The path of each executable we will compile.

--- a/tests/composition/multi_type.cpp
+++ b/tests/composition/multi_type.cpp
@@ -36,11 +36,9 @@ secondf_ret_t test_composition(firstf_arg_t n)
 	
 	composition<firstf_ret_t(firstf_arg_t)> comp1(func1);
 	composition<secondf_ret_t(secondf_arg_t)> comp2(func2);
-	volatile composition<secondf_ret_t(firstf_arg_t)> comp(comp2 * comp1);
+	composition<secondf_ret_t(firstf_arg_t)> comp(comp2 * comp1);
 	
-	volatile secondf_ret_t ret = comp(n).get();
-	
-	return ret;
+	return comp(n);
 }
 
 int main()

--- a/tests/composition/multi_type.cpp
+++ b/tests/composition/multi_type.cpp
@@ -21,7 +21,7 @@ firstf_ret_t func1(firstf_arg_t n)
 
 secondf_ret_t func2(secondf_arg_t n)
 {
-	return n > std::numeric_limits<secondf_arg_t>::max();
+	return n > 10000;
 }
 
 static composition<firstf_ret_t(firstf_arg_t)> comp1(func1);
@@ -31,13 +31,9 @@ static composition<secondf_ret_t(firstf_arg_t)> comp(comp2 * comp1);
 
 void test_composition(firstf_arg_t n)
 {
-//	composition<firstf_ret_t(firstf_arg_t)> comp1(func1);
-//	composition<secondf_ret_t(secondf_arg_t)> comp2(func2);
-//	composition<secondf_ret_t(firstf_arg_t)> comp(comp2 * comp1);
-	
 	std::cout << "original: " << n << std::endl;
 	std::cout << "comp1(n): " << comp1(n).get() << std::endl;
-	std::cout << "comp(n):  " << comp(n).get() << std::endl;
+	std::cout << "comp(n):  " << (comp(n).get() ? "true" : "false") << std::endl;
 	
 	std::cout << std::endl;
 }

--- a/tests/composition/multi_type.cpp
+++ b/tests/composition/multi_type.cpp
@@ -1,3 +1,7 @@
+/*
+	This tests compositing functions/compositions with input/output types.
+*/
+
 #include "../../src/composition.hpp"
 #include <cstdint>
 using fondue::composition;

--- a/tests/composition/single_type.cpp
+++ b/tests/composition/single_type.cpp
@@ -1,3 +1,7 @@
+/*
+	This tests compositing functions/compositions with equal input/output types.
+*/
+
 #include "../../src/composition.hpp"
 typedef signed long long ret_t;
 typedef fondue::composition<ret_t(ret_t)> composition;

--- a/tests/composition/single_type.cpp
+++ b/tests/composition/single_type.cpp
@@ -28,7 +28,9 @@ bool test_composition(ret_t n)
 	composition comp2(func2);
 	composition comp3(func3);
 	
-	return (comp3 * (comp1 * comp2))(n).get() == n;
+	//auto tempcomp = comp1 * comp2;
+	//return (comp3 * tempcomp)(n) == n;
+	return (comp3 * (comp1 * comp2))(n) == n;
 }
 
 int main()

--- a/tests/composition/static_comp.cpp
+++ b/tests/composition/static_comp.cpp
@@ -1,0 +1,23 @@
+#include "../../src/composition.hpp"
+#include <functional>
+typedef int arg_t;
+typedef int ret_t;
+using fondue::composition;
+
+ret_t func(arg_t n)
+{
+	return n + 1;
+}
+
+static composition<ret_t(arg_t)> comp = std::function<ret_t(arg_t)>(func);
+
+int main()
+{
+	for (int i = 0; i < 100; i++) {
+		if (comp(i) != i + 1) {
+			return 1;
+		}
+	}
+	
+	return 0;
+}


### PR DESCRIPTION
Closes #5 
This is a full rewrite of composition.hpp and an addition of a new test file. Composition objects can now be called more than once.